### PR TITLE
Set default mouse cursor theme to Qogir-Dark in schema overrides

### DIFF
--- a/schemas/92_org.mate.peripherals-mouse.gschema.override
+++ b/schemas/92_org.mate.peripherals-mouse.gschema.override
@@ -1,0 +1,2 @@
+[org.mate.peripherals-mouse]
+cursor-theme='Qogir-Dark'


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Define a default mouse configuration via a dedicated org.mate.peripherals-mouse schema override file.